### PR TITLE
Support using the library from UIKit

### DIFF
--- a/Sources/WelcomeSheet/Views/FormSheetWrapper.swift
+++ b/Sources/WelcomeSheet/Views/FormSheetWrapper.swift
@@ -2,13 +2,13 @@
 
 import SwiftUI
 
-class ModalUIHostingController<Content>: UIHostingController<Content>, UIPopoverPresentationControllerDelegate where Content : View {
+public class ModalUIHostingController<Content>: UIHostingController<Content>, UIPopoverPresentationControllerDelegate where Content : View {
     var isDismissedBySliding: Bool
     let onDismiss: (() -> Void)
     
     required init?(coder: NSCoder) { fatalError("") }
     
-    init(onDismiss: @escaping () -> Void, isSlideToDismissDisabled: Bool, rootView: Content) {
+    public init(onDismiss: @escaping () -> Void, isSlideToDismissDisabled: Bool, rootView: Content) {
         self.onDismiss = onDismiss
         self.isDismissedBySliding = false
         super.init(rootView: rootView)
@@ -18,7 +18,7 @@ class ModalUIHostingController<Content>: UIHostingController<Content>, UIPopover
         isModalInPresentation = isSlideToDismissDisabled
     }
     
-    func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+    public func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
         isDismissedBySliding = true
         onDismiss()
     }

--- a/Sources/WelcomeSheet/Views/WelcomeSheetController.swift
+++ b/Sources/WelcomeSheet/Views/WelcomeSheetController.swift
@@ -1,0 +1,38 @@
+//
+//  WelcomeSheetController.swift
+//  
+//
+//  Created by Kevin Romero Peces-Barba on 2/10/22.
+//
+
+import SwiftUI
+
+public class WelcomeSheetController {
+    private var _showSheet: Bool = false
+    private lazy var showSheet: Binding<Bool> = .init {
+        self._showSheet
+    } set: { newValue in
+        self._showSheet = newValue
+        self.onDismiss()
+    }
+    private var welcomeView: some View {
+        WelcomeSheetView(pages: pages)
+            .environment(\.showingSheet, showSheet)
+    }
+
+    private var pages: [WelcomeSheetPage]
+    private var onDismiss: () -> Void
+
+    init(pages: [WelcomeSheetPage], onDismiss: @escaping () -> Void) {
+        self.pages = pages
+        self.onDismiss = onDismiss
+    }
+
+    func get() -> UIViewController {
+        return ModalUIHostingController(onDismiss: onDismiss, isSlideToDismissDisabled: true, rootView: welcomeView)
+    }
+
+    public static func get(pages: [WelcomeSheetPage], onDismiss: @escaping () -> Void) -> UIViewController {
+        WelcomeSheetController(pages: pages, onDismiss: onDismiss).get()
+    }
+}


### PR DESCRIPTION
Hi! I love the library, thank you for making it!

This PR is more of a suggestion/discussion prompt to see what would be the best approach to support using WelcomeSheet from UIKit.

I was looking into integrating some SwiftUI on a UIKit app, and seems like the onboarding might be a good place for it using `WelcomeSheet`. I wasn't sure of how I should tackle it, since this was designed to be used as a view modifier, so I came up with the attached helper class.

It takes advantage of your `ModalUIHostingController` to create an erased `UIViewController` that can be used from UIKit to be presented. Here is how it would be used:

```swift
final class ViewController: UIViewController {
    // ... All your setup

    // MARK: Welcome Sheet
    private var welcomeSheetController: UIViewController?

    func showWelcome() {
        let pages: [WelcomeSheetPage] = [
            .init(
                title: "Welcome to my App!",
                rows: [
                    .init(
                        imageSystemName: "questionmark.circle",
                        title: "Lorem Ipsum",
                        content: "dolor sit amet"
                    ),
                ],
                mainButtonTitle: "OK!"
            )
        ]

        self.welcomeSheetController = WelcomeSheetController.get(pages: pages) { [weak self] in
            self?.welcomeSheetController?.dismiss(animated: true)
        }

        present(self.welcomeSheetController!, animated: true)
    }
}
```

Of course this is a simple and naive approach to it (my goal was to not change any APIs for now). Ideally, `WelcomeSheetView` would be exposed to use in an arbitrary `UIHostingController` but I'm not sure of what would need to be done to adapt the logic to decouple the `WelcomeSheetView` from the `ModalUIHostingController` as it is now, since it uses the environment to handle the dismissal.

An idea would be to make `WelcomeSheetView` receive a closure that handles the tap in the last page's button. This way, the `FormSheet` would handle the dismissal for SwiftUI and in UIKit world the caller would be responsible to do it in a similar way to my example.

Let me know if all this makes sense or if I am missing something and there is a better approach!

Cheers 😄 